### PR TITLE
Add storage Link support; update logistics & population

### DIFF
--- a/src/manager.link.js
+++ b/src/manager.link.js
@@ -1,9 +1,15 @@
 /**
  * MANAGER: Link Network
- * VERSION: 1.2.0
+ * VERSION: 1.3.0
  * DESCRIPTION: Διαχειρίζεται την αυτόματη μεταφορά ενέργειας μεταξύ των Links.
+ * * CHANGES 1.3.0:
+ * - Προσθήκη εγγραφής του Storage Link ID στο Room Memory (storageLinkId).
+ * - Δυνατότητα αναγνώρισης του Link από το Logistics Manager για αυτόματη εκκένωση/τροφοδοσία.
  */
-const LIMIT_FOR_START_TRANSFER=400;
+
+const LIMIT_FOR_START_TRANSFER = 400;
+const STORAGE_LINK_ID = "storageLinkId";
+
 class LinkManager {
     /**
      * @param {Room} room - Το αντικείμενο του δωματίου που διαχειρίζεται ο manager.
@@ -13,11 +19,7 @@ class LinkManager {
         this.links = room.find(FIND_MY_STRUCTURES, {
             filter: { structureType: STRUCTURE_LINK }
         });
-       // console.log("Link number "+this.links.length);
         this.categories = this.categorizeLinks();
-        
-        // Εκτύπωση categories στη κονσόλα
-       //  this.debugCategories(); 
     }
 
     /**
@@ -35,13 +37,12 @@ class LinkManager {
      * Κύρια λογική εκτέλεσης.
      */
     run() {
-        
         if (this.links.length < 2) return; 
 
         const { senders, storageLink, controllerLink } = this.categories;
 
         for (const sender of senders) {
-            // Έλεγχος αν ο Sender έχει ενέργεια (τουλάχιστον LIMIT_FOR_START_TRANSFER για να αξίζει το transfer fee)
+            // Έλεγχος αν ο Sender έχει ενέργεια και δεν είναι σε cooldown
             if (sender.store.getUsedCapacity(RESOURCE_ENERGY) < LIMIT_FOR_START_TRANSFER || sender.cooldown > 0) {
                 continue;
             }
@@ -61,7 +62,7 @@ class LinkManager {
     }
 
     /**
-     * Κατηγοριοποιεί τα links βάσει θέσης.
+     * Κατηγοριοποιεί τα links βάσει θέσης και ενημερώνει τη μνήμη.
      */
     categorizeLinks() {
         const senders = [];
@@ -75,16 +76,21 @@ class LinkManager {
         for (const link of this.links) {
             let isSpecial = false;
 
+            // Link κοντά στον Controller (Receiver)
             if (controller && link.pos.inRangeTo(controller, 4)) {
                 controllerLink = link;
                 receivers.push(link);
                 isSpecial = true;
             } 
+            // Link κοντά στο Storage (Hub)
             else if (storage && link.pos.inRangeTo(storage, 2)) {
                 storageLink = link;
                 isSpecial = true;
+                // Ενημέρωση Memory για χρήση από άλλους managers (π.χ. Logistics)
+                this.room.memory[STORAGE_LINK_ID] = storageLink.id;
             }
 
+            // Αν δεν είναι ειδικό Link, θεωρείται Sender (από Sources)
             if (!isSpecial) {
                 senders.push(link);
             }
@@ -94,7 +100,7 @@ class LinkManager {
     }
 }
 
-module.exports = {
+module.exports = {STORAGE_LINK_ID,
     run: function(roomName) {
         const room = Game.rooms[roomName];
         if (!room) return;

--- a/src/manager.logistics.js
+++ b/src/manager.logistics.js
@@ -1,26 +1,28 @@
 // manager.logistics.js
 const movementManager = require('manager.movement'); 
+const{STORAGE_LINK_ID}=require('manager.link');
 /*
-version 1.0.0
+version 1.1.0
+- Added high priority for Storage Link emptying using room.memory.storageLinkId
 */
 const PRIORITIES = {
+    STORAGE_LINK: 105, // Υψηλότερη προτεραιότητα από Spawn/Extension για να αδειάζει αμέσως το δίκτυο
     SPAWN_EXTENSION: 100,
-    TOWER: 80,
-    CONTROLLER_CONTAINER: 70,
-    LAB: 40,
-    TERMINAL: 5,
-    NUKER: 35 , 
-    FACTORY: 35, 
-    POWER_SPAWN: 35,
-    STORAGE: 10,
-    
     DROP_ENERGY: 100,
     SOURCE_CONTAINER: 90,
     RECOVERY_CONTAINER: 85,
+    TOWER: 80,
     RUIN: 80,
+    STORAGE_SOURCE: 76,
+    STORAGE_LINK_NORMAL: 75, // Backup priority
+    CONTROLLER_CONTAINER: 70,
+    LAB: 40,
     TERMINAL_SOURCE: 40,
-    STORAGE_LINK: 75,
-    STORAGE_SOURCE: 76
+    NUKER: 35, 
+    FACTORY: 35, 
+    POWER_SPAWN: 35,
+    STORAGE: 10,
+    TERMINAL: 5
 };
 
 const TARGET_FULL_PERCENT = { 
@@ -189,18 +191,27 @@ const logisticsManager = {
     findSourcesForTarget: function(room, target) {
         const sources = [];
         
+        // 1. Dropped Energy
         room.find(FIND_DROPPED_RESOURCES, {
             filter: r => r.resourceType === RESOURCE_ENERGY && r.amount > 200
         }).forEach(energy => sources.push({
             id: energy.id, type: 'dropped', priority: PRIORITIES.DROP_ENERGY, obj: energy
         }));
    
+        // 2. Structures
         room.find(FIND_STRUCTURES).forEach(s => {
             let priority = 0;
             let condition = false;
             if (s.id === target.id) return;
 
             switch (s.structureType) {
+                case STRUCTURE_LINK:
+                    // Αν είναι το Storage Link, δίνουμε μέγιστη προτεραιότητα για να αδειάσει
+                    if (room.memory[STORAGE_LINK_ID] === s.id && s.store[RESOURCE_ENERGY] > 0) {
+                        priority = PRIORITIES.STORAGE_LINK;
+                        condition = true;
+                    }
+                    break;
                 case STRUCTURE_CONTAINER:
                     if (s.store[RESOURCE_ENERGY] > 100 && this.isContainerNearSource(s)) {
                         priority = PRIORITIES.SOURCE_CONTAINER;
@@ -214,12 +225,6 @@ const logisticsManager = {
                 case STRUCTURE_TERMINAL:
                     if (s.my && s.store[RESOURCE_ENERGY] > 1000) {
                         priority = PRIORITIES.TERMINAL_SOURCE; 
-                        condition = true;
-                    }
-                    break;
-                case STRUCTURE_LINK:
-                    if (room.memory.storageLinkId === s.id && s.store[RESOURCE_ENERGY] > 100) {
-                        priority = PRIORITIES.STORAGE_LINK;
                         condition = true;
                     }
                     break;
@@ -237,6 +242,7 @@ const logisticsManager = {
             }
         });
         
+        // 3. Ruins
         room.find(FIND_RUINS, {
             filter: ruin => ruin.store[RESOURCE_ENERGY] > 50
         }).forEach(ruin => sources.push({
@@ -251,7 +257,7 @@ const logisticsManager = {
         const storage = room.storage;
         
         this.findSourcesForTarget(room, {id: null}).forEach(source => {
-            if (source.type === 'dropped' || source.type === 'ruin') {
+            if (source.type === 'dropped' || source.type === 'ruin' || (room.memory[STORAGE_LINK_ID] === source.id)) {
                 sources.push(source);
             }
         });
@@ -263,6 +269,12 @@ const logisticsManager = {
             let condition = false;
 
             switch (s.structureType) {
+                case STRUCTURE_LINK:
+                    if (room.memory[STORAGE_LINK_ID] === s.id && s.store[RESOURCE_ENERGY] > 0) {
+                        priority = PRIORITIES.STORAGE_LINK;
+                        condition = true;
+                    }
+                    break;
                 case STRUCTURE_CONTAINER:
                     if (s.store[RESOURCE_ENERGY] > 100 && this.isContainerNearSource(s)) {
                         priority = PRIORITIES.SOURCE_CONTAINER;
@@ -270,12 +282,6 @@ const logisticsManager = {
                     }
                     else if (room.memory.recoveryContainerId === s.id && s.store[RESOURCE_ENERGY] > 100) {
                         priority = PRIORITIES.RECOVERY_CONTAINER;
-                        condition = true;
-                    }
-                    break;
-                case STRUCTURE_LINK:
-                    if (room.memory.storageLinkId === s.id && s.store[RESOURCE_ENERGY] > 100) {
-                        priority = PRIORITIES.STORAGE_LINK;
                         condition = true;
                     }
                     break;
@@ -385,7 +391,7 @@ const logisticsManager = {
 
         let bestTask = null;
         let bestScore = -Infinity;
-        const topTasks = tasks.slice(0, 10); 
+        const topTasks = tasks.slice(0, 15); // Αυξήθηκε λίγο το εύρος για να πιάνει τα νέα link tasks
 
         for (const task of topTasks) {
             const reservation = reservations[task.id];
@@ -440,8 +446,6 @@ const logisticsManager = {
         }
     },
 
-    // --- ΚΙΝΗΣΗ ΜΕ ΧΡΗΣΗ TOY movementManager ---
-
     collectFromSource: function(creep, assignment) {
         const source = Game.getObjectById(assignment.sourceId);
         
@@ -495,7 +499,7 @@ const logisticsManager = {
                 this.completeTask(creep);
             }
         } else {
-            movementManager.smartMove(creep, target, 1); // <-- ΑΛΛΑΓΗ
+            movementManager.smartMove(creep, target, 1);
         }
     },
 
@@ -503,11 +507,12 @@ const logisticsManager = {
         switch (sourceType) {
             case 'dropped': return source.amount > 20;
             case 'ruin': return source.store[RESOURCE_ENERGY] > 20;
+            case 'link': // Προσθήκη για το Link
             case 'container':
             case 'recoveryContainer':
             case 'terminal':
             case 'storageLink':
-            case 'storage': return source.store[RESOURCE_ENERGY] > 50;
+            case 'storage': return source.store[RESOURCE_ENERGY] > 0; // Αδειάζουμε μέχρι τέλους
             default: return false;
         }
     },
@@ -516,6 +521,7 @@ const logisticsManager = {
         switch (sourceType) {
             case 'dropped': return creep.pickup(source);
             case 'ruin':
+            case 'link': // Προσθήκη για το Link
             case 'container':
             case 'recoveryContainer':
             case 'terminal':
@@ -537,7 +543,6 @@ const logisticsManager = {
             delete reservations[assignments[creep.name].taskId];
             delete assignments[creep.name];
             
-            // Clean move memory
             delete creep.memory._lastPos;
             delete creep.memory._stuckCount;
 
@@ -572,7 +577,7 @@ const logisticsManager = {
         visual.text(`Tasks: ${tasks.length}`, 1, y++, { align: 'left', color: '#ffff00' });
         
         tasks.slice(0, 5).forEach((task, index) => {
-            const info = `${task.taskType}: ${task.sourceType}->${task.targetType} (prio:${task.priority})`;
+            const info = `${task.taskType}: ${task.sourceId === room.memory.storageLinkId ? 'STORAGE_LINK' : task.sourceType}->${task.targetType} (prio:${task.priority})`;
             visual.text(info, 1, y++, { align: 'left', color: '#ffffff' });
         });
     }

--- a/src/spawn.populationManager.js
+++ b/src/spawn.populationManager.js
@@ -1,12 +1,8 @@
 /**
  * MODULE: Population Manager
  * ΠΕΡΙΓΡΑΦΗ: Διαχειρίζεται τα όρια πληθυσμού και την κατάσταση Recovery ανά δωμάτιο.
- * VERSION 1.4.0
- * - Refactored σε εξειδικευμένες μεθόδους για ευαναγνωσία.
- * - Ενσωμάτωση Builder-as-Upgrader στρατηγικής.
- * 1.2.0 Προσθήκη λειτουργία containers. 
- * - Αν υπάρχει έστω και ένα container τότε αλλάζει η διαχείριση του πληθυσμού.
- * 1.1.0 Ακύρωση λειτουργίας storageContainer. 
+ * VERSION 1.5.1
+ * - Διόρθωση false-positive emergency: Το δωμάτιο δεν μπαίνει σε recovery αν υπάρχει αποθηκευμένη ενέργεια.
  */
 const { ROLES } = require('spawn.constants');
 
@@ -17,12 +13,15 @@ class PopulationManager {
     calculateLimits(room) {
         const context = this._getContext(room);
 
-        // 1. Έλεγχος για Recovery Mode (Αν έχει "σπάσει" η οικονομία)
+        // 1. Έλεγχος για Recovery Mode (Αν έχει "σπάσει" η πραγματική οικονομία)
         if (this._isEmergency(room, context)) {
             return this._getRecoveryLimits(context);
         }
 
         // 2. Επιλογή στρατηγικής βάσει υποδομών
+        if (context.link_count > 1) { 
+            return this._getLinkLimits(context);
+        }
         if (context.storage) {
             return this._getStorageLimits(context);
         } else if (context.hasContainers) {
@@ -33,21 +32,64 @@ class PopulationManager {
     }
 
     /**
+     * Στρατηγική όταν υπάρχει δίκτυο Links.
+     */
+    _getLinkLimits(context) {
+        const energy = context.storage ? context.storage.store[RESOURCE_ENERGY] : 0;
+        
+        let haulerCount = 1;
+        if (context.link_count < context.sources + 1) {
+            haulerCount = 2;
+        }
+
+        let limits = {
+            [ROLES.SIMPLE_HARVESTER]: 0,
+            [ROLES.STATIC_HARVESTER]: context.sources,
+            [ROLES.HAULER]: haulerCount,
+            [ROLES.UPGRADER]: 1,
+            [ROLES.BUILDER]: 1,
+            isRecovery: false
+        };
+
+        if (context.level < 8) {
+            if (energy > 150000) limits[ROLES.BUILDER] = 2;
+            if (energy > 400000) limits[ROLES.BUILDER] = 4;
+        } else {
+            if (context.hasConstruction) { 
+                limits[ROLES.BUILDER] = 2;
+            }
+        }
+
+        return limits;
+    }
+
+    /**
      * Συγκεντρώνει όλα τα απαραίτητα δεδομένα για τους υπολογισμούς.
      */
     _getContext(room) {
         const containers = room.find(FIND_STRUCTURES, {
             filter: s => s.structureType === STRUCTURE_CONTAINER
         });
+        const links = room.find(FIND_STRUCTURES, {
+            filter: s => s.structureType === STRUCTURE_LINK
+        });
+        
+        // Υπολογισμός συνολικής αποθηκευμένης ενέργειας σε containers/storage
+        let storedEnergy = 0;
+        if (room.storage) storedEnergy += room.storage.store[RESOURCE_ENERGY];
+        containers.forEach(c => storedEnergy += c.store[RESOURCE_ENERGY]);
+
         return {
             room: room,
             sources: room.find(FIND_SOURCES).length,
             level: room.controller.level,
             storage: room.storage,
+            link_count: links.length,
             hasContainers: containers.length > 0,
-            hasConstruction: room.find(FIND_CONSTRUCTION_SITES).length > 0
+            hasConstruction: room.find(FIND_CONSTRUCTION_SITES).length > 0,
+            storedEnergy: storedEnergy
         };
-    } // end of _getContext
+    }
 
     /**
      * Ελέγχει αν το δωμάτιο βρίσκεται σε κατάσταση έκτακτης ανάγκης.
@@ -55,16 +97,27 @@ class PopulationManager {
     _isEmergency(room, context) {
         const roomCreeps = _.filter(Game.creeps, c => c.memory.homeRoom === room.name);
         
+        // 1. Έλεγχος Harvesters: Αν δεν υπάρχει κανένας, είναι πάντα emergency.
         const hasHarvesters = _.some(roomCreeps, c => 
             (c.memory.role === ROLES.STATIC_HARVESTER || c.memory.role === ROLES.SIMPLE_HARVESTER) && 
             (c.ticksToLive > 40 || c.spawning)
         );
+        if (!hasHarvesters) return true;
 
-        // Αν έχουμε containers/storage, χρειαζόμαστε οπωσδήποτε haulers
+        // 2. Έλεγχος Haulers:
         const needsHauler = context.hasContainers || context.storage;
-        const hasHaulers = _.some(roomCreeps, c => c.memory.role === ROLES.HAULER);
+        const hasHaulers = _.some(roomCreeps, c => c.memory.role === ROLES.HAULER && (c.ticksToLive > 30 || c.spawning));
 
-        return !hasHarvesters || (needsHauler && !hasHaulers);
+        if (needsHauler && !hasHaulers) {
+            // Αν δεν έχουμε Haulers, αλλά το Storage/Containers έχουν ενέργεια, 
+            // το Spawn μπορεί να βγάλει νέο Hauler μόνο του. ΔΕΝ είναι emergency.
+            // Αν όμως η αποθηκευμένη ενέργεια είναι πολύ χαμηλή (π.χ. < 1000), τότε κινδυνεύουμε.
+            if (context.storedEnergy < 1000) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -72,11 +125,11 @@ class PopulationManager {
      */
     _getRecoveryLimits(context) {
         return {
-            [ROLES.SIMPLE_HARVESTER]: context.sources ,
+            [ROLES.SIMPLE_HARVESTER]: context.sources,
             [ROLES.STATIC_HARVESTER]: 0,
-            [ROLES.HAULER]: context.hasContainers ? 1 : 0,
+            [ROLES.HAULER]: (context.hasContainers || context.storage) ? 1 : 0,
             [ROLES.UPGRADER]: 0,
-            [ROLES.BUILDER]: 1, // Ένας builder για τυχόν repairs σε κρίσιμα σημεία
+            [ROLES.BUILDER]: 1,
             isRecovery: true
         };
     }
@@ -95,19 +148,17 @@ class PopulationManager {
             isRecovery: false
         };
 
-        // Αυξάνουμε τους Builders (που κάνουν και Upgrade) αν έχουμε πλεόνασμα ενέργειας
         if (context.level < 8) {
             if (energy > 200000) limits[ROLES.BUILDER] = 3;
             if (energy > 500000) limits[ROLES.BUILDER] = 5;
-            
         } else {
-			if (context.hasConstruction) { 
-				limits[ROLES.BUILDER] = 3;
-			}
-		}
+            if (context.hasConstruction) { 
+                limits[ROLES.BUILDER] = 3;
+            }
+        }
 
         return limits;
-    } // end of _getStorageLimits
+    }
 
     /**
      * Στρατηγική όταν υπάρχουν Containers αλλά όχι Storage.
@@ -116,9 +167,9 @@ class PopulationManager {
         return {
             [ROLES.SIMPLE_HARVESTER]: 0,
             [ROLES.STATIC_HARVESTER]: context.sources,
-            [ROLES.HAULER]: context.sources ,
+            [ROLES.HAULER]: context.sources,
             [ROLES.UPGRADER]: 1,
-            [ROLES.BUILDER]: 3, // Αυξημένοι builders λόγω έλλειψης storage
+            [ROLES.BUILDER]: 3,
             isRecovery: false
         };
     }
@@ -135,7 +186,7 @@ class PopulationManager {
             [ROLES.BUILDER]: 2,
             isRecovery: false
         };
-    } // end of _getEarlyGameLimits
+    }
 
     /**
      * Ενημερώνει το Memory του δωματίου.
@@ -149,7 +200,7 @@ class PopulationManager {
         if (!Memory.rooms[roomName]) Memory.rooms[roomName] = {};
         Memory.rooms[roomName].populationLimits = newLimits;
         Memory.rooms[roomName].isRecovery = newLimits.isRecovery;
-    } // end of updateRoomLimits
+    }
 }
 
 module.exports = new PopulationManager();


### PR DESCRIPTION
Link manager: bump version, save storage Link ID to room.memory (storageLinkId), export STORAGE_LINK_ID constant, and categorize links so Logistics can identify the storage link.

Logistics manager: import STORAGE_LINK_ID, prioritize emptying the storage Link, treat links as energy sources, include link source handling (pickup/conditions), increase task scan window, adjust priorities and visuals to surface storage link tasks.

Population manager: bump version, add link-aware population strategy (_getLinkLimits), compute storedEnergy, fix false-positive emergency detection (harvesters/haulers checks and storedEnergy threshold), and minor tweaks to limits and formatting.
closes #6 
